### PR TITLE
Fix shutdown on restart

### DIFF
--- a/octoprint_phom/__init__.py
+++ b/octoprint_phom/__init__.py
@@ -265,8 +265,11 @@ class OphomPlugin(octoprint.plugin.SettingsPlugin,
 			if(self._settings.get(['security_connection_lost']) == True):
 				requests.put("http://{}/api/{}/lights/{}/state".format(self._settings.get(['hue_ip']), self._settings.get(['hue_token']), self._settings.get(['light_id'])), json={"on": False})
 		elif(event == "Shutdown"):
-			if(self._settings.get(['auto_off']) == True):
-				self.turn_off()
+			# The plugin doesn't know if it concerns a octoprint restart, system reboot or a system shutdown. Only a shutdown should be performed on the last one.
+			# As long as that is unknown disable code below:
+			# if(self._settings.get(['auto_off']) == True):
+			# 	self.turn_off()
+			pass
 
 
 	def turn_off(self):


### PR DESCRIPTION
Based on the [plugin events](https://docs.octoprint.org/en/master/events/index.html) no difference can be made between a octoprint software restart, system reboot or system shutdown. All will get the "Shutdown" event. Only on system shutdown a power-off is acceptable.

While not clear how to detect the system shutdown, disable the power_off on shutdown event.
